### PR TITLE
add go offline button to startup page

### DIFF
--- a/lib/ui/startup/connect.dart
+++ b/lib/ui/startup/connect.dart
@@ -35,16 +35,31 @@ class _ConnectFormState extends State<ConnectForm> {
                 icon: Icon(Icons.desktop_windows), labelText: serverURLFieldLabel, hintText: "Polaris server address"),
           ),
           Padding(
-              padding: const EdgeInsets.only(top: 32),
-              child: Consumer<connection.Manager>(builder: (context, connectionManager, child) {
-                if (connectionManager.state != connection.State.disconnected) {
-                  return const CircularProgressIndicator();
-                }
-                return ElevatedButton(onPressed: _onConnectPressed, child: const Text(connectButtonLabel));
-              })),
+            padding: const EdgeInsets.only(top: 32),
+            child: Row(children: [
+              TextButton(onPressed: _onGoOfflinePressed, child: const Text(goOfflineButtonLabel)),
+              const Spacer(),
+              _buildConnectWidget(context),
+            ])
+          )
         ],
       ),
     );
+  }
+
+  Widget _buildConnectWidget(BuildContext context) {
+    return Consumer<connection.Manager>(builder: (context, connectionManager, child) {
+      if (connectionManager.state != connection.State.disconnected) {
+        return const CircularProgressIndicator();
+      } else {
+        return ElevatedButton(onPressed: _onConnectPressed, child: const Text(connectButtonLabel));
+      }
+    });
+  }
+
+  void _onGoOfflinePressed() {
+    _connectionManager.disconnect();
+    _connectionManager.startOffline();
   }
 
   Future _onConnectPressed() async {

--- a/lib/ui/startup/login.dart
+++ b/lib/ui/startup/login.dart
@@ -42,22 +42,26 @@ class _LoginFormState extends State<LoginForm> {
             ),
           ),
           Padding(
-              padding: const EdgeInsets.only(top: 32),
-              child: Consumer<authentication.Manager>(builder: (context, authenticationManager, child) {
-                if (authenticationManager.state != authentication.State.unauthenticated) {
-                  return const CircularProgressIndicator();
-                }
-                return Row(
-                  children: [
-                    TextButton(onPressed: _onDisconnectPressed, child: const Text(disconnectButtonLabel)),
-                    const Spacer(),
-                    ElevatedButton(onPressed: _onLoginPressed, child: const Text(loginButtonLabel)),
-                  ],
-                );
-              })),
+            padding: const EdgeInsets.only(top: 32),
+            child: Row(children: [
+              TextButton(onPressed: _onDisconnectPressed, child: const Text(disconnectButtonLabel)),
+              const Spacer(),
+              _buildLoginWidget(context),
+            ])
+          )
         ],
       ),
     );
+  }
+
+  Widget _buildLoginWidget(BuildContext context) {
+    return Consumer<authentication.Manager>(builder: (context, authenticationManager, child) {
+      if (authenticationManager.state != authentication.State.unauthenticated) {
+        return const CircularProgressIndicator();
+      } else {
+        return ElevatedButton(onPressed: _onLoginPressed, child: const Text(loginButtonLabel));
+      }
+    });
   }
 
   Future _onDisconnectPressed() async {

--- a/lib/ui/startup/page.dart
+++ b/lib/ui/startup/page.dart
@@ -1,11 +1,15 @@
 import 'package:animations/animations.dart';
+import 'package:get_it/get_it.dart';
 import 'package:flutter/material.dart' hide ConnectionState;
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:polaris/core/authentication.dart' as authentication;
 import 'package:polaris/core/connection.dart' as connection;
 import 'package:polaris/ui/startup/connect.dart';
 import 'package:polaris/ui/startup/login.dart';
+import 'package:polaris/ui/strings.dart';
 import 'package:provider/provider.dart';
+
+final getIt = GetIt.instance;
 
 enum StartupState {
   reconnecting,
@@ -41,12 +45,25 @@ class StartupPage extends StatelessWidget {
   Widget _buildWidgetForState(StartupState state) {
     switch (state) {
       case StartupState.reconnecting:
-        return const CircularProgressIndicator();
+        return Padding(
+          padding: const EdgeInsets.only(top: 32),
+          child: Row(children: [
+            TextButton(onPressed: _onGoOfflinePressed, child: const Text(goOfflineButtonLabel)),
+            const Spacer(),
+            const CircularProgressIndicator(),
+          ])
+        );
       case StartupState.connect:
         return const ConnectForm();
       case StartupState.login:
         return const LoginForm();
     }
+  }
+
+  void _onGoOfflinePressed() {
+    final connectionManager = getIt<connection.Manager>();
+    connectionManager.disconnect();
+    connectionManager.startOffline();
   }
 
   Widget _buildContent() {

--- a/lib/ui/strings.dart
+++ b/lib/ui/strings.dart
@@ -16,6 +16,7 @@ const usernameFieldLabel = 'Username';
 const passwordFieldLabel = 'Password';
 const connectButtonLabel = 'CONNECT';
 const disconnectButtonLabel = 'DISCONNECT';
+const goOfflineButtonLabel = 'GO OFFLINE';
 const loginButtonLabel = 'LOGIN';
 const offlineModeButtonLabel = 'BROWSE OFFLINE';
 


### PR DESCRIPTION
Currently, if there is no connection to a polaris server available, there is no way  to go offline.
This adds a go offline button to the startup loading page and the startup connection page. And makes the disconnect button of the login page persistent. I don't really like how this moves the loading indicator to the side though. Maybe you've got an idea how to make that look better.