### PR TITLE
enable high refresh rates using flutter_displaymode

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:audio_session/audio_session.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_displaymode/flutter_displaymode.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:get_it/get_it.dart';
 import 'package:http/http.dart' as http;
@@ -131,6 +132,7 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Settings.init();
   await _registerSingletons();
+  await FlutterDisplayMode.setHighRefreshRate();
   await JustAudioBackground.init(
     androidNotificationIcon: "drawable/notification_icon",
     androidNotificationChannelName: 'Polaris Audio Playback',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -153,6 +153,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.3.0"
+  flutter_displaymode:
+    dependency: "direct main"
+    description:
+      name: flutter_displaymode
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.1"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   rxdart: ^0.27.4
   shared_preferences: ^2.0.5
   uuid: ^3.0.4
+  flutter_displaymode: ^0.4.1
 
 dev_dependencies:
   flutter_lints: ^2.0.1


### PR DESCRIPTION
Apparently flutter doesn't set high refresh rates such as 90 or 120hz by itself. This adds the `flutter_displaymode` package which does just that.